### PR TITLE
Fix profile hook error handling

### DIFF
--- a/hooks/use-profile.ts
+++ b/hooks/use-profile.ts
@@ -40,9 +40,12 @@ export function useProfile(): UseProfileResult {
         if (profileError || !userProfile) {
           setIsLoading(false);
           setError("Error fetching user profile");
+          setProfile(null);
+          return;
         }
 
         setProfile(userProfile);
+        setIsLoading(false);
       } catch (error) {
         setIsLoading(false);
         setError("Error fetching user profile");


### PR DESCRIPTION
## Summary
- fix `useProfile` hook to avoid setting profile when fetch fails

## Testing
- `npx tsc -p tsconfig.json` *(fails: cannot find module declarations)*