### PR TITLE
Fix typo in feedback synthesis prompt

### DIFF
--- a/app/api/feedback/synthesize/route.ts
+++ b/app/api/feedback/synthesize/route.ts
@@ -63,7 +63,7 @@ Given multiple pieces of feedback about a project, your task is to:
 2. Provide actionable recommendations
 3. Present the information in a clear, organized format
 
-Please analyze the following feedback and provide a comprehensive synthesis. KEEP IT BRIEF WITHOUT LOSING INFORMATION. Provide your response in simple text form without delimters:`;
+Please analyze the following feedback and provide a comprehensive synthesis. KEEP IT BRIEF WITHOUT LOSING INFORMATION. Provide your response in simple text form without delimiters:`;
 
     const completion = await openai.chat.completions.create({
       model: "gpt-4o-mini",


### PR DESCRIPTION
## Summary
- fix a typo in the system prompt inside the feedback synthesis route

## Testing
- `npm run lint` *(fails: `next` not found)*