### PR TITLE
Fix track criteria type retrieval

### DIFF
--- a/components/dashboard/organizer/tracks/TracksTab.tsx
+++ b/components/dashboard/organizer/tracks/TracksTab.tsx
@@ -66,7 +66,21 @@ export function TracksTab({
         variant: "destructive",
       });
     } else {
-      setTracks(data || []);
+      const typedTracks = (data || []).map((track) => ({
+        ...track,
+        scoring_criteria: track.scoring_criteria
+          ? {
+              ...track.scoring_criteria,
+              criteria: track.scoring_criteria.criteria.map(
+                (c: ScoringCriterion) => ({
+                  ...c,
+                  type: c.type || "numeric",
+                })
+              ),
+            }
+          : track.scoring_criteria,
+      }));
+      setTracks(typedTracks);
     }
   };
 
@@ -130,7 +144,22 @@ export function TracksTab({
         .eq("event_id", eventId);
 
       if (refreshedTracks && event) {
-        const updatedTracks = refreshedTracks as unknown as EventTrack[];
+        const updatedTracks = (refreshedTracks as unknown as EventTrack[]).map(
+          (track) => ({
+            ...track,
+            scoring_criteria: track.scoring_criteria
+              ? {
+                  ...track.scoring_criteria,
+                  criteria: track.scoring_criteria.criteria.map(
+                    (c: ScoringCriterion) => ({
+                      ...c,
+                      type: c.type || "numeric",
+                    })
+                  ),
+                }
+              : track.scoring_criteria,
+          })
+        );
         setTracks(updatedTracks);
 
         const updatedEvent = {

--- a/components/project-scoring/default-scoring.tsx
+++ b/components/project-scoring/default-scoring.tsx
@@ -64,18 +64,24 @@ export function DefaultScoring({
         if (trackError) throw trackError;
 
         if (trackData?.scoring_criteria?.criteria) {
-          setCriteria(trackData.scoring_criteria.criteria);
-          
+          const typedCriteria = trackData.scoring_criteria.criteria.map(
+            (criterion: ScoringCriterion) => ({
+              ...criterion,
+              type: criterion.type || "numeric",
+            })
+          );
+          setCriteria(typedCriteria);
+
           // Initialize form with default values
           const defaultScores: Record<string, number | string> = {};
-          trackData.scoring_criteria.criteria.forEach((criterion: ScoringCriterion) => {
+          typedCriteria.forEach((criterion: ScoringCriterion) => {
             if (criterion.type === "multiplechoice") {
               defaultScores[criterion.id] = "";
             } else {
               defaultScores[criterion.id] = criterion.min || 1;
             }
           });
-          
+
           form.reset({ scores: defaultScores, comments: "" });
         }
 


### PR DESCRIPTION
## Summary
- include criterion type for tracks loaded in OrganizerDashboard
- ensure TracksTab fetches typed criteria
- normalize criteria types when refreshing tracks
- preserve criterion type when loading scoring form

## Testing
- `npm run lint` *(fails: next not found)*