### PR TITLE
Allow string values in score records

### DIFF
--- a/components/dashboard/judge-dashboard.tsx
+++ b/components/dashboard/judge-dashboard.tsx
@@ -17,7 +17,7 @@ interface JudgeDashboardProps {
 }
 
 interface ProjectScore {
-  scores: Record<string, number>;
+  scores: Record<string, number | string>;
   comments: string;
 }
 

--- a/components/dashboard/organizer/scores/index.tsx
+++ b/components/dashboard/organizer/scores/index.tsx
@@ -19,7 +19,7 @@ interface DashboardProjectScore {
   project_id: string;
   track_id: string;
   event_id: string;
-  scores: Record<string, number>;
+  scores: Record<string, number | string>;
   projects: {
     project_name: string;
     lead_name: string;

--- a/components/scoring/project-scoring-form.tsx
+++ b/components/scoring/project-scoring-form.tsx
@@ -37,7 +37,7 @@ export function ProjectScoringForm({
   const [isLoading, setIsLoading] = useState(false);
   const [formData, setFormData] = useState<ScoreFormData>(() => {
     // Initialize scores with default values
-    const initialScores: Record<string, number> = {};
+    const initialScores: Record<string, number | string> = {};
     criteria.forEach((criterion) => {
       initialScores[criterion.id] = Math.floor(
         ((criterion.max ?? defaultMax) + (criterion.min ?? defaultMin)) / 2
@@ -52,7 +52,7 @@ export function ProjectScoringForm({
 
   useEffect(() => {
     // Reset form data when track changes
-    const initialScores: Record<string, number> = {};
+    const initialScores: Record<string, number | string> = {};
     criteria.forEach((criterion) => {
       initialScores[criterion.id] = Math.floor(
         ((criterion.max ?? defaultMax) + (criterion.min ?? defaultMin)) / 2

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -55,7 +55,7 @@ export interface Database {
           judge_id: string
           track_id: string
           event_id: string
-          scores: Record<string, number>
+          scores: Record<string, number | string>
           comments: string | null
           created_at: string
           updated_at: string

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -156,14 +156,14 @@ export interface ProjectScore {
   judge_id: string;
   track_id: string;
   event_id: string;
-  scores: Record<string, number>;
+  scores: Record<string, number | string>;
   comments?: string;
   created_at: string;
   updated_at: string;
 }
 
 export interface ScoreFormData {
-  scores: Record<string, number>;
+  scores: Record<string, number | string>;
   comments?: string;
 }
 


### PR DESCRIPTION
## Summary
- broaden `scores` type for `ProjectScore` and `ScoreFormData`
- update database type definitions
- adjust components to support `number | string` score values

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: missing script)*