### PR TITLE
Use numeric investor decisions

### DIFF
--- a/components/dashboard/judge-dashboard.tsx
+++ b/components/dashboard/judge-dashboard.tsx
@@ -412,36 +412,39 @@ export function JudgeDashboard({ eventId }: JudgeDashboardProps) {
                           ) : projectScore ? (
                             <div className="space-y-2 mt-2">
                               {/* For investment mode, display investment decision */}
-                              {projectScore.scores.investor_decision ? (
+                              {projectScore.scores.investor_decision !==
+                              undefined ? (
                                 <div className="space-y-2">
-                                  <div className="font-medium">
-                                    Decision:{" "}
-                                    <span
-                                      className={`${
-                                        String(
-                                          projectScore.scores.investor_decision
-                                        ) === "invest"
-                                          ? "text-green-600"
-                                          : String(
-                                              projectScore.scores
-                                                .investor_decision
-                                            ) === "maybe"
-                                          ? "text-yellow-500"
-                                          : "text-red-600"
-                                      }`}
-                                    >
-                                      {String(
-                                        projectScore.scores.investor_decision
-                                      ) === "invest"
-                                        ? "Invest"
-                                        : String(
-                                            projectScore.scores
-                                              .investor_decision
-                                          ) === "maybe"
-                                        ? "Maybe"
-                                        : "Pass"}
-                                    </span>
-                                  </div>
+                                  {(() => {
+                                    const decisionValue =
+                                      projectScore.scores
+                                        .investor_decision as number | string;
+                                    const decisionStr =
+                                      typeof decisionValue === "number"
+                                        ? decisionValue === 2
+                                          ? "invest"
+                                          : decisionValue === 1
+                                          ? "maybe"
+                                          : "pass"
+                                        : decisionValue;
+                                    const colorClass =
+                                      decisionStr === "invest"
+                                        ? "text-green-600"
+                                        : decisionStr === "maybe"
+                                        ? "text-yellow-500"
+                                        : "text-red-600";
+                                    return (
+                                      <div className="font-medium">
+                                        Decision: <span className={colorClass}>
+                                          {decisionStr === "invest"
+                                            ? "Invest"
+                                            : decisionStr === "maybe"
+                                            ? "Maybe"
+                                            : "Pass"}
+                                        </span>
+                                      </div>
+                                    );
+                                  })()}
 
                                   {projectScore.scores.interest_level !==
                                     undefined && (

--- a/components/project-scoring/investor-view.tsx
+++ b/components/project-scoring/investor-view.tsx
@@ -24,6 +24,18 @@ export function InvestorView({
   judgeId,
   trackId,
 }: InvestorViewProps) {
+  const decisionMap = {
+    invest: 2,
+    maybe: 1,
+    pass: 0,
+  } as const;
+
+  const decisionReverseMap = {
+    2: "invest",
+    1: "maybe",
+    0: "pass",
+  } as const;
+
   const [decision, setDecision] = useState<string | null>(null);
   const [interestLevel, setInterestLevel] = useState<number>(0);
   const [comments, setComments] = useState("");
@@ -68,9 +80,15 @@ export function InvestorView({
 
         if (data) {
           setExistingScore(data);
-          // Convert special investor scoring format back to form values
-          if (data.scores && data.scores.investor_decision) {
-            setDecision(data.scores.investor_decision);
+          // Convert stored values back to form-friendly values
+          if (data.scores && data.scores.investor_decision !== undefined) {
+            const stored = data.scores.investor_decision as number | string;
+            if (typeof stored === "number") {
+              setDecision(decisionReverseMap[stored]);
+            } else {
+              // backwards compatibility with old string values
+              setDecision(stored);
+            }
             setInterestLevel(data.scores.interest_level || 0);
             setComments(data.comments || "");
           }
@@ -94,7 +112,8 @@ export function InvestorView({
 
       // Prepare the score data in a special format for investor view
       const scoreData = {
-        investor_decision: decision,
+        investor_decision:
+          decision !== null ? decisionMap[decision as keyof typeof decisionMap] : null,
         interest_level: interestLevel,
       };
 


### PR DESCRIPTION
## Summary
- store investor decisions numerically
- display investor decision numbers properly

## Testing
- `npm run lint` *(fails: `next` not found)*