### PR TITLE
Fix schedule time wrapping on mobile

### DIFF
--- a/app/events/[id]/overview/page.tsx
+++ b/app/events/[id]/overview/page.tsx
@@ -159,7 +159,7 @@ export default async function EventOverviewPage({ params }: PageProps) {
                         <span className="font-medium text-gray-800">
                           {event.name}
                         </span>
-                        <span className="text-gray-500">{event.time}</span>
+                        <span className="text-gray-500 whitespace-nowrap">{event.time}</span>
                       </div>
                     ))}
                   </div>


### PR DESCRIPTION
## Summary
- avoid wrapping times in event schedule on the overview page

## Testing
- `npm run lint` *(fails: `next` not found)*