### PR TITLE
Use slug-based URLs for events

### DIFF
--- a/app/events/[id]/dashboard/page.tsx
+++ b/app/events/[id]/dashboard/page.tsx
@@ -9,6 +9,7 @@ import { JudgeDashboard } from "@/components/dashboard/judge-dashboard";
 import { MentorDashboard } from "@/components/dashboard/mentor-dashboard";
 import { OrganizerDashboard } from "@/components/dashboard/organizer";
 import { useState, useEffect } from "react";
+import { isValidUUID } from "@/app/utils/supabase/queries";
 
 export default function DashboardPage() {
   const params = useParams();
@@ -19,11 +20,19 @@ export default function DashboardPage() {
 
   useEffect(() => {
     const resolveEventId = async () => {
-      const { data } = await supabase
-        .from("events")
-        .select("event_id")
-        .or(`slug.eq.${slug},event_id.eq.${slug}`)
-        .maybeSingle();
+      const isUUID = isValidUUID(slug);
+
+      let query = supabase.from("events").select("event_id");
+
+      if (isUUID) {
+        // If it's a UUID, check both slug and event_id
+        query = query.or(`slug.eq.${slug},event_id.eq.${slug}`);
+      } else {
+        // If it's not a UUID, only check slug
+        query = query.eq("slug", slug);
+      }
+
+      const { data } = await query.maybeSingle();
       if (data) setEventId(data.event_id);
     };
     resolveEventId();

--- a/app/events/[id]/dashboard/page.tsx
+++ b/app/events/[id]/dashboard/page.tsx
@@ -29,10 +29,6 @@ export default function DashboardPage() {
     resolveEventId();
   }, [slug]);
 
-  if (!eventId) {
-    return <div>Loading...</div>;
-  }
-
   useEffect(() => {
     // Simulate loading time for the dashboard, give time for the data to load
     const timer = setTimeout(() => {
@@ -41,6 +37,10 @@ export default function DashboardPage() {
 
     return () => clearTimeout(timer);
   }, []);
+
+  if (!eventId) {
+    return <div>Loading...</div>;
+  }
 
   const renderDashboard = () => {
     switch (userRole) {

--- a/app/events/[id]/dashboard/page.tsx
+++ b/app/events/[id]/dashboard/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useParams } from "next/navigation";
+import { supabase } from "@/lib/supabase";
 import { useEventRegistration } from "@/components/event-registration-provider";
 import { EventRole } from "@/lib/types";
 import { ParticipantDashboard } from "@/components/dashboard/participant-dashboard";
@@ -11,9 +12,26 @@ import { useState, useEffect } from "react";
 
 export default function DashboardPage() {
   const params = useParams();
-  const eventId = params.id as string;
+  const slug = params.id as string;
+  const [eventId, setEventId] = useState<string | null>(null);
   const { userRole } = useEventRegistration();
   const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const resolveEventId = async () => {
+      const { data } = await supabase
+        .from("events")
+        .select("event_id")
+        .or(`slug.eq.${slug},event_id.eq.${slug}`)
+        .maybeSingle();
+      if (data) setEventId(data.event_id);
+    };
+    resolveEventId();
+  }, [slug]);
+
+  if (!eventId) {
+    return <div>Loading...</div>;
+  }
 
   useEffect(() => {
     // Simulate loading time for the dashboard, give time for the data to load

--- a/app/events/[id]/feed/page.tsx
+++ b/app/events/[id]/feed/page.tsx
@@ -39,12 +39,25 @@ export default async function PublicFeedPage({
   const [{ id }, resolvedSearchParams] = await Promise.all([params, searchParams])
   const currentPage = parseInt(resolvedSearchParams.page || "1")
 
+  const { data: event } = await supabase
+    .from("events")
+    .select("event_id, slug")
+    .or(`slug.eq.${id},event_id.eq.${id}`)
+    .single()
+
+  if (!event) {
+    return <div>Event not found</div>
+  }
+
+  const eventId = event.event_id
+  const slug = event.slug || id
+
   try {
     // Fetch all public feed items
     const { data: feedItems, error: feedError } = await supabase
       .from("platform_engagement")
       .select("*")
-      .eq("event_id", id)
+      .eq("event_id", eventId)
       .eq("is_private", false)
       .order("created_at", { ascending: false })
 
@@ -121,7 +134,7 @@ export default async function PublicFeedPage({
         {totalPages > 1 && (
           <div className="flex justify-center space-x-2 mt-6">
             {currentPage > 1 && (
-              <Link href={`/events/${id}/feed/public?page=${currentPage - 1}`}>
+              <Link href={`/events/${slug}/feed/public?page=${currentPage - 1}`}>
                 <Button variant="outline">Previous</Button>
               </Link>
             )}
@@ -129,7 +142,7 @@ export default async function PublicFeedPage({
               Page {currentPage} of {totalPages}
             </span>
             {currentPage < totalPages && (
-              <Link href={`/events/${id}/feed/public?page=${currentPage + 1}`}>
+              <Link href={`/events/${slug}/feed/public?page=${currentPage + 1}`}>
                 <Button variant="outline">Next</Button>
               </Link>
             )}

--- a/app/events/[id]/feed/page.tsx
+++ b/app/events/[id]/feed/page.tsx
@@ -1,26 +1,27 @@
-import { Card, CardContent } from "@/components/ui/card"
-import { Avatar, AvatarFallback } from "@/components/ui/avatar"
-import { createSupabaseClient } from "@/app/utils/supabase/server"
-import { Button } from "@/components/ui/button"
-import Link from "next/link"
-import { formatDistanceToNow } from "date-fns"
+import { Card, CardContent } from "@/components/ui/card";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { createSupabaseClient } from "@/app/utils/supabase/server";
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+import { formatDistanceToNow } from "date-fns";
+import { isValidUUID } from "@/app/utils/supabase/queries";
 
-const ITEMS_PER_PAGE = 5
+const ITEMS_PER_PAGE = 5;
 
 type UserProfile = {
-  uid: string
-  display_name: string | null
-}
+  uid: string;
+  display_name: string | null;
+};
 
 type FeedItem = {
-  id: string
-  content: string
-  created_at: string
-  type: string
-  display_name: string | null
-  user_id: string
-  user?: UserProfile
-}
+  id: string;
+  content: string;
+  created_at: string;
+  type: string;
+  display_name: string | null;
+  user_id: string;
+  user?: UserProfile;
+};
 
 interface PageProps {
   params: Promise<{ id: string }>;
@@ -31,26 +32,37 @@ export default async function PublicFeedPage({
   params,
   searchParams,
 }: PageProps) {
-  const supabase = await createSupabaseClient()
-  
+  const supabase = await createSupabaseClient();
+
   // Note: This Next.js warning is a false positive. In Server Components,
   // route params are already resolved and don't need to be awaited.
   // See: https://github.com/vercel/next.js/discussions/54929
-  const [{ id }, resolvedSearchParams] = await Promise.all([params, searchParams])
-  const currentPage = parseInt(resolvedSearchParams.page || "1")
+  const [{ id }, resolvedSearchParams] = await Promise.all([
+    params,
+    searchParams,
+  ]);
+  const currentPage = parseInt(resolvedSearchParams.page || "1");
 
-  const { data: event } = await supabase
-    .from("events")
-    .select("event_id, slug")
-    .or(`slug.eq.${id},event_id.eq.${id}`)
-    .single()
+  const isUUID = isValidUUID(id);
 
-  if (!event) {
-    return <div>Event not found</div>
+  let query = supabase.from("events").select("event_id, slug");
+
+  if (isUUID) {
+    // If it's a UUID, check both slug and event_id
+    query = query.or(`slug.eq.${id},event_id.eq.${id}`);
+  } else {
+    // If it's not a UUID, only check slug
+    query = query.eq("slug", id);
   }
 
-  const eventId = event.event_id
-  const slug = event.slug || id
+  const { data: event } = await query.single();
+
+  if (!event) {
+    return <div>Event not found</div>;
+  }
+
+  const eventId = event.event_id;
+  const slug = event.slug || id;
 
   try {
     // Fetch all public feed items
@@ -59,46 +71,49 @@ export default async function PublicFeedPage({
       .select("*")
       .eq("event_id", eventId)
       .eq("is_private", false)
-      .order("created_at", { ascending: false })
+      .order("created_at", { ascending: false });
 
     if (feedError) {
-      console.error("Error fetching feed:", feedError)
-      throw feedError
+      console.error("Error fetching feed:", feedError);
+      throw feedError;
     }
 
     if (!feedItems) {
-      console.error("No feed items found")
-      return <div>No feed items found</div>
+      console.error("No feed items found");
+      return <div>No feed items found</div>;
     }
 
     // Get unique user IDs
-    const userIds = [...new Set(feedItems.map(item => item.user_id))]
+    const userIds = [...new Set(feedItems.map((item) => item.user_id))];
 
     // Fetch user display names only
     const { data: users, error: usersError } = await supabase
       .from("user_profiles")
       .select("uid, display_name")
-      .in("uid", userIds)
+      .in("uid", userIds);
 
     if (usersError) {
-      console.error("Error fetching users:", usersError)
-      throw usersError
+      console.error("Error fetching users:", usersError);
+      throw usersError;
     }
 
     // Create a map of user data
-    const userMap = new Map(users?.map(user => [user.uid, user]) || [])
+    const userMap = new Map(users?.map((user) => [user.uid, user]) || []);
 
     // Combine feed items with user data
-    const enrichedFeedItems: FeedItem[] = feedItems.map(item => ({
+    const enrichedFeedItems: FeedItem[] = feedItems.map((item) => ({
       ...item,
-      user: userMap.get(item.user_id)
-    }))
+      user: userMap.get(item.user_id),
+    }));
 
     // Handle pagination
-    const totalItems = enrichedFeedItems.length
-    const totalPages = Math.ceil(totalItems / ITEMS_PER_PAGE)
-    const startIndex = (currentPage - 1) * ITEMS_PER_PAGE
-    const paginatedItems = enrichedFeedItems.slice(startIndex, startIndex + ITEMS_PER_PAGE)
+    const totalItems = enrichedFeedItems.length;
+    const totalPages = Math.ceil(totalItems / ITEMS_PER_PAGE);
+    const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
+    const paginatedItems = enrichedFeedItems.slice(
+      startIndex,
+      startIndex + ITEMS_PER_PAGE
+    );
 
     return (
       <div className="space-y-6">
@@ -109,20 +124,28 @@ export default async function PublicFeedPage({
               <div className="flex items-start space-x-4">
                 <Avatar>
                   <AvatarFallback>
-                    {item.display_name?.[0] || item.user?.display_name?.[0] || '?'}
+                    {item.display_name?.[0] ||
+                      item.user?.display_name?.[0] ||
+                      "?"}
                   </AvatarFallback>
                 </Avatar>
                 <div className="space-y-1">
                   <h3 className="font-semibold">
-                    {item.display_name || item.user?.display_name || 'Anonymous User'}
+                    {item.display_name ||
+                      item.user?.display_name ||
+                      "Anonymous User"}
                   </h3>
                   <p className="text-gray-600">{item.content}</p>
                   <div className="flex items-center space-x-2">
                     <p className="text-sm text-gray-500">
-                      {formatDistanceToNow(new Date(item.created_at), { addSuffix: true })}
+                      {formatDistanceToNow(new Date(item.created_at), {
+                        addSuffix: true,
+                      })}
                     </p>
                     <span className="text-sm text-gray-500">•</span>
-                    <span className="text-sm text-gray-500 capitalize">{item.type}</span>
+                    <span className="text-sm text-gray-500 capitalize">
+                      {item.type}
+                    </span>
                   </div>
                 </div>
               </div>
@@ -134,7 +157,9 @@ export default async function PublicFeedPage({
         {totalPages > 1 && (
           <div className="flex justify-center space-x-2 mt-6">
             {currentPage > 1 && (
-              <Link href={`/events/${slug}/feed/public?page=${currentPage - 1}`}>
+              <Link
+                href={`/events/${slug}/feed/public?page=${currentPage - 1}`}
+              >
                 <Button variant="outline">Previous</Button>
               </Link>
             )}
@@ -142,16 +167,18 @@ export default async function PublicFeedPage({
               Page {currentPage} of {totalPages}
             </span>
             {currentPage < totalPages && (
-              <Link href={`/events/${slug}/feed/public?page=${currentPage + 1}`}>
+              <Link
+                href={`/events/${slug}/feed/public?page=${currentPage + 1}`}
+              >
                 <Button variant="outline">Next</Button>
               </Link>
             )}
           </div>
         )}
       </div>
-    )
+    );
   } catch (error) {
-    console.error("Feed error:", error)
-    return <div>Error loading feed. Please try again later.</div>
+    console.error("Feed error:", error);
+    return <div>Error loading feed. Please try again later.</div>;
   }
 }

--- a/app/events/[id]/layout.tsx
+++ b/app/events/[id]/layout.tsx
@@ -28,6 +28,7 @@ export default async function Layout({
     .from("events")
     .select(`
       event_id,
+      slug,
       event_name,
       event_date,
       location,
@@ -35,7 +36,7 @@ export default async function Layout({
       event_description,
       cover_image_url
     `)
-    .eq("event_id", id)
+    .or(`slug.eq.${id},event_id.eq.${id}`)
     .single();
 
   if (!event) {
@@ -45,7 +46,7 @@ export default async function Layout({
   return (
     <div className="min-h-screen flex flex-col">
       {isAuthenticated ? <AuthNavbar /> : <Navbar />}
-      <EventRegistrationWrapper eventId={id}>
+      <EventRegistrationWrapper eventId={event.event_id}>
         <main className="flex-1 overflow-auto">
           <div className="max-w-5xl mx-auto px-4 sm:px-6 py-4 sm:py-6 space-y-4 sm:space-y-6 w-full">
             <EventHeader
@@ -54,7 +55,7 @@ export default async function Layout({
               eventDate={event.event_date}
               location={event.location}
               description={event.event_blurb || event.event_description}
-              eventId={id}
+              eventId={event.slug || event.event_id}
             />
               {children}
           </div>
@@ -75,7 +76,7 @@ export async function generateMetadata({
   const { data: event } = await supabase
     .from("events")
     .select("event_name")
-    .eq("event_id", id)
+    .or(`slug.eq.${id},event_id.eq.${id}`)
     .single();
 
   return {

--- a/app/events/[id]/participants/page.tsx
+++ b/app/events/[id]/participants/page.tsx
@@ -16,10 +16,26 @@ export default async function PublicParticipantsPage({ params }: PageProps) {
   const supabase = await createSupabaseClient();
   const { id } = await params;
 
+  const { data: event } = await supabase
+    .from("events")
+    .select("event_id")
+    .or(`slug.eq.${id},event_id.eq.${id}`)
+    .single();
+
+  if (!event) {
+    return (
+      <Card>
+        <CardContent className="p-6">
+          <div className="text-red-500">Event not found</div>
+        </CardContent>
+      </Card>
+    );
+  }
+
   const { data: participants, error } = await supabase
     .from("user_event_roles")
     .select("user_id, user_profiles!user_id(uid, display_name)")
-    .eq("event_id", id)
+    .eq("event_id", event.event_id)
     .eq("role", "participant")
     .overrideTypes<
       Array<{

--- a/app/events/[id]/submit/page.tsx
+++ b/app/events/[id]/submit/page.tsx
@@ -8,9 +8,22 @@ import { useParams } from "next/navigation";
 // Project Submission Page
 export default function ProjectSubmissionPage() {
   const params = useParams();
-  const eventId = params.id as string;
+  const slug = params.id as string;
+  const [eventId, setEventId] = useState<string | null>(null);
   const [userEmail, setUserEmail] = useState<string | null>(null);
   const [userName, setUserName] = useState<string | null>(null);
+
+  useEffect(() => {
+    const resolveEventId = async () => {
+      const { data } = await supabase
+        .from("events")
+        .select("event_id")
+        .or(`slug.eq.${slug},event_id.eq.${slug}`)
+        .maybeSingle();
+      if (data) setEventId(data.event_id);
+    };
+    resolveEventId();
+  }, [slug]);
 
   useEffect(() => {
     const getUser = async () => {
@@ -43,6 +56,10 @@ export default function ProjectSubmissionPage() {
     };
     getUser();
   }, []);
+
+  if (!eventId) {
+    return <div>Loading...</div>;
+  }
 
   return (
     <div className="container mx-auto py-8">

--- a/app/profile/[userId]/page.tsx
+++ b/app/profile/[userId]/page.tsx
@@ -179,6 +179,7 @@ export default function ProfilePage() {
           .select(
             `
                 event_id,
+                slug,
                 event_name,
                 event_date,
                 location,
@@ -401,7 +402,7 @@ export default function ProfilePage() {
                       )}
                       <CardHeader>
                         <CardTitle className="text-xl hover:text-blue-600">
-                          <Link href={`/events/${event.event_id}/overview`}>
+                          <Link href={`/events/${event.slug || event.event_id}/overview`}>
                             {event.event_name}
                           </Link>
                         </CardTitle>

--- a/app/utils/supabase/queries.ts
+++ b/app/utils/supabase/queries.ts
@@ -1,0 +1,8 @@
+/**
+ * Check if a string is a valid UUID format
+ */
+export function isValidUUID(str: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+    str
+  );
+}

--- a/components/events/events-list.tsx
+++ b/components/events/events-list.tsx
@@ -9,6 +9,7 @@ import { EventRole } from "@/lib/types";
 
 interface Event {
   event_id: string;
+  slug?: string;
   event_name: string;
   event_date: string;
   location: string;
@@ -91,7 +92,7 @@ export function EventsList({ events }: EventsListProps) {
 
         return (
           <Link
-            href={`/events/${event.event_id}/overview`}
+            href={`/events/${event.slug || event.event_id}/overview`}
             key={event.event_id}
             className="block h-full"
           >

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -22,6 +22,7 @@ export interface UserProfile {
 
 export type EventItem = {
   event_id: string;
+  slug?: string;
   event_name: string;
   event_date: string;
   location: string;


### PR DESCRIPTION
## Summary
- add `slug` to event types
- fetch event records by slug or ID
- use slug for event links
- resolve slug to event_id on client pages
- link events by slug in profile view

## Testing
- `npm run lint` *(fails: next not found)*