### PR TITLE
Fix project description height

### DIFF
--- a/features/projects/components/displays/ProjectBoard/ProjectBoard.tsx
+++ b/features/projects/components/displays/ProjectBoard/ProjectBoard.tsx
@@ -94,8 +94,10 @@ const ProjectBoard = ({
                       <p className="text-sm text-gray-500">
                         Lead: {project.lead_name}
                       </p>
-                      <CardDescription className="text-gray-600 text-sm flex-grow overflow-hidden">
-                          {project.project_description}
+                      <CardDescription
+                        className="text-gray-600 text-sm line-clamp-3 overflow-hidden min-h-[3.75rem]"
+                      >
+                        {project.project_description}
                       </CardDescription>
 
                       {/* QR Code Section */}


### PR DESCRIPTION
## Summary
- clamp project description to a consistent height in `ProjectBoard`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683bb1fd88a88323a9caa060704c4847